### PR TITLE
Add Fastly facter facts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Consume CDN IP Addresses through Facter
+# Consume Cloudflare and Fastly IP Addresses through Facter
 
 ## What is this?
 
@@ -13,6 +13,8 @@ Below the list of Cloudflare IP addresses is the following caveat:
 It's unclear what the frequency of "regularly" is, but it sure would be nice to not have to worry about it. I originally solved this problem with a big pile of bash -- you can see what that looked like [over here](https://github.com/byronwolfman/real_ip_hydrator) (but TL;DR: it grabs and parses Cloudflare's published list of IPv4 and IPv6 addresses and shoves them into an nginx config). This was all well and good but I worried that the script and puppet might clobber each other, and anyway, it doesn't seem fantastic to have two different things managing nginx's configuration.
 
 Now, if puppet could consume that information as a fact, we'd be cooking.
+
+(Note that only Cloudflare instructions and examples are provided for brevity. The Fastly facts work exactly the same; just substitute `cloudflare_ipv4s` for `fastly_ipv4s` and `cloudflare_ipv6s` with `fastly_ipv6s` and you're done. Note that at the time of writing, Fastly does not publish any IPv6 addresses, so the latter array will be empty. This is normal.)
 
 ## How it works
 
@@ -57,9 +59,10 @@ Alternatively you can access the facts in the template directly as a top-level v
 
 This script makes certain assumptions which may cause you grief:
 
-- The script assumes return-delimited lists
+- The script assumes return-delimited lists.
 - The script assumes you are using Cloudflare (but Fastly might make an appearance in the future!)
-- The script returns an empty array to facter if it can't download the lists
+- The script returns an empty array to facter if it can't download the lists.
+- The net/http and openssl module are imported for both facts; the json module is additionally imported for Fastly facts.
 
 Use/modify/deploy at your own risk.
 

--- a/fastly_ips.rb
+++ b/fastly_ips.rb
@@ -1,0 +1,47 @@
+# Download the list of Fastly IPv4 and IPv6 addresses used by their CDN for
+# proxying requests and provide that information in the form of facter arrays.
+# In the event that the addresses cannot be retrieved, facter will output an
+# empty array for each.
+
+# Paired with nginx's real_ip module, this is a handy way to correctly log
+# visitor traffic, rather than logging the CDN itself as the visitor. See:
+# https://docs.fastly.com/guides/securing-communications/accessing-fastlys-ip-ranges
+
+require 'facter'
+require 'json'
+require 'net/http'
+require 'openssl'
+
+# IPv4 regex found via http://www.regexpal.com/93987 on 2016-09-24
+# IPv6 regex found via http://www.regexpal.com/93988 on 2016-09-24
+ipv4_regex = /([0-9]{1,3}\.){3}[0-9]{1,3}(\/([0-9]|[1-2][0-9]|3[0-2]))?/
+ipv6_regex = /s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:)))(%.+)?s*(\/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8]))?/
+
+Facter.add(:fastly_ipv4s) do
+  setcode do
+    http = Net::HTTP.new('api.fastly.com', 443)
+    http.use_ssl = true
+    http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+
+    response = http.request_get('/public-ip-list')
+    JSON.parse(response.body)['addresses'].select do |ip|
+      ip =~ ipv4_regex
+    end
+  end
+end
+
+# Note that at the time of writing (Nov 10 2016), Fastly's CDN only uses (or at
+# least only publishes) IPv4 addresses. Therefore the expected output here is an
+# empty array. The block below exists pre-emptively, should this change.
+Facter.add(:fastly_ipv6s) do
+  setcode do
+    http = Net::HTTP.new('api.fastly.com', 443)
+    http.use_ssl = true
+    http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+
+    response = http.request_get('/public-ip-list')
+    JSON.parse(response.body)['addresses'].select do |ip|
+      ip =~ ipv6_regex
+    end
+  end
+end


### PR DESCRIPTION
## Consume Fastly IP addresses too!

Not content with collecting just Cloudflare's IP addresses, there is now a `fastly_ips.rb` which collects Fastly's IP addresses too! There are a couple of gotchas:

1. `fastly_ipv4s` and `fastly_ipv6s` are both output as arrays, but savvy Fastly users will already know that Fastly only [uses/publishes IPv4 addresses!](https://api.fastly.com/public-ip-list) The latter array will therefore be empty. In the spirit of automating all things however, fact is there and will parse any IPv6 address that gets published to https://api.fastly.com/public-ip-list should it happen in the future. Maybe Fastly will publish those addresses somewhere else though in which case _D'OH._
1. Fastly delivers addresses in a big ball of JSON, so we're using the json module. This may cause grief if you have a super old version of ruby or OS (I KNOW WHO YOU ARE). I may publish a very gross workaround (hint: `split('"')`).